### PR TITLE
Option not to monitor after stop request; ReadMe edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,12 +506,12 @@ either of which would also provoke the needless
 > Retries continue until the database reaches a final status (usually
 `stopped`). If someone starts the database manually after it enters `stopped`
 status but before Stay-Stopped detects this, Stay-Stopped will stop the
-database a second time. A race condition, yes, but one that doesn't interfere
-with the main goal of _stopping_! Wait until a database has been in `stopped`
-status for 9 minutes (the default [in]visibility timeout) before starting it.
-If this is onerous, change `FollowUntilStopped` to `false` in CloudFormation.
-Retries will stop after the successful call to `stop_db_cluster` or
-`stop_db_instance`, eliminating the race condition.
+database a second time. A race condition, yes, but one that is documented and
+doesn't interfere with the main goal: stopping! Wait until a database has been
+in `stopped` status for 9 minutes (the default [in]visibility timeout) before
+starting it. To eliminate the problem, change `FollowUntilStopped` to `false`
+in CloudFormation. Retries will stop right after the successful call to
+`stop_db_cluster` or `stop_db_instance`.
 
 ### Further Reading
 

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ database a second time. A race condition, yes, but one that doesn't interfere
 with the main goal of _stopping_! Wait until a database has been in `stopped`
 status for 9 minutes (the default [in]visibility timeout) before starting it.
 If this is onerous, change `FollowUntilStopped` to `false` in CloudFormation.
-retries will stop after the successful call to `stop_db_cluster` or
+Retries will stop after the successful call to `stop_db_cluster` or
 `stop_db_instance`, eliminating the race condition.
 
 ### Further Reading

--- a/README.md
+++ b/README.md
@@ -421,10 +421,10 @@ status, _before_ the next status check?
 [Lambda has a 15-minute maximum timeout](https://docs.aws.amazon.com/lambda/latest/dg/configuration-timeout.html).
 The function might never get a chance to request that the database be stopped.
 
-> Waiting _within_ the Lambda function might seem wasteful, but 15 minutes
-costs less than 2¢ &mdash; negligible for a function triggered once per
-database per week. Even though Lambda's maximum timeout is too short for this
-application, I appreciate the author's instinct for minimal infrastructure.
+> Waiting within the Lambda function might seem wasteful, but 15 minutes costs
+less than 2¢ &mdash; negligible for a function triggered once per database per
+week. Even though Lambda's maximum timeout is too short for this application,
+I appreciate the author's instinct for minimal infrastructure.
 
 ### Step Function Alternative
 
@@ -459,8 +459,8 @@ from `stopping` to `stopped`.
 ### Stay-Stopped: Queue Before Lambda
 
 Stay-Stopped requires only one Lambda function, but inserts an SQS queue
-between EventBridge and Lambda. The Lambda function never waits for the
-database. SQS counts up toward a
+between EventBridge and Lambda. Waiting occurs outside the Lambda function.
+SQS counts up toward a
 [message [in]visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html),
 making it possible to periodically retry the Lambda function, with the
 original EventBridge event message, until the return value indicates success.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ You can keep an EC2 compute instance stopped as long as you want, but it's not
 possible to stop an RDS or Aurora database longer than 7 days. After AWS
 starts your database on the 7th day, this tool automatically stops it again.
 
-Stay-Stopped is for databases you use sporadically, perhaps for development
-and testing. If it would cost too much to keep a database running but take too
-long to re-create it, this tool might save you money, time, or both.
+Stay-Stopped is for databases you use sporadically:
+
+- development
+- testing
+- occasional reference
+- retired, but kept just in case
+
+If it would cost too much to keep a database running but take too long to
+re-create it, this tool might save you money, time, or both.
 
 AWS does not charge for database instance hours while an
 [RDS database instance is stopped](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html#USER_StopInstance.Benefits)
@@ -40,18 +46,20 @@ The design is simple but robust:
   and
   [RDS-EVENT-0153](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Events.Messages.html#RDS-EVENT-0153)
   (Aurora database cluster).
-  You do not need to set any opt-in or opt-out tags. As long as _you_, rather
-  than _AWS_, started your database this time, Stay-Stopped won't stop it.&sup1;
+
+- You do not need to set any opt-in or opt-out tags. As long as _you_, rather
+  than _AWS_, started your currently-running databases, Stay-Stopped won't
+  stop them.&sup1;
 
 - <a name="design-idempotence"></a>Stopping stuff is inherently
   idempotent: keep trying until it stops! This tool tries every 9 minutes
   until the database is stopped, an unexpected error occurs, or 24 hours pass.
 
-  > Many alternative solutions introduce a latent bug (a
+  > Many alternatives introduce a latent bug (a
   [race condition](https://en.wikipedia.org/wiki/Race_condition))
-  by checking whether a database is ready _before_ trying to stop it,
-  insisting on catching the database while it's `available`, or not waiting
-  long enough. To understand why this matters and what can go wrong, see
+  by checking status _before_ trying to stop a database, always expecting to
+  catch the database while it's `available`, or not waiting long enough. To
+  understand why this matters and what can go wrong, see
   [Perspective](#perspective),
   below.
 
@@ -66,14 +74,14 @@ The design is simple but robust:
 - Once in a while it's still important to start a database before its
   maintenance window and leave it running until the window closes.
 
-&sup1; Wait until the database has been in `stopped` status for 9 minutes
-before you start it.
+&sup1; Before manually starting a database, wait until it has been stopped for
+at least 9 minutes.
 
 ### Detailed Diagram
 
 Click to view the architecture diagram and flowchart:
 
-[<img src="media/stay-stopped-aws-rds-aurora-architecture-and-flow-thumb.png" alt="Relational Database Service Event Bridge events '0153' and '0154' (database started after exceeding 7-day maximum stop time) go to the main Simple Queue Service queue. The Amazon Web Services Lambda function stops RDS instance or the Aurora cluster. If the database's status is invalid, the queue message becomes visible again in 9 minutes. A final status of 'stopping', 'deleting' or 'deleted' stops retries, as does an error status. After 160 tries (24 hours), the message goes to the error (dead letter) SQS queue." height="144" />](media/stay-stopped-aws-rds-aurora-architecture-and-flow.png?raw=true "Architecture diagram and flowchart for Stay Stopped, RDS and Aurora!")
+[<img src="media/stay-stopped-aws-rds-aurora-architecture-and-flow-thumb.png" alt="Relational Database Service Event Bridge events '0153' and '0154' (database started after exceeding 7-day maximum stop time) go to the main Simple Queue Service queue. The Amazon Web Services Lambda function stops the RDS instance or the Aurora cluster. If the database's status is invalid, the queue message becomes visible again in 9 minutes. A final status of 'stopping', 'deleting' or 'deleted' ends retries, as does an error status. After 160 tries (24 hours), the message goes to the error (dead letter) SQS queue." height="144" />](media/stay-stopped-aws-rds-aurora-architecture-and-flow.png?raw=true "Architecture diagram and flowchart for Stay Stopped, RDS and Aurora!")
 
 ## Get Started
 
@@ -92,18 +100,28 @@ Click to view the architecture diagram and flowchart:
 
  3. Wait 8 days, then check that your
     [RDS or Aurora database](https://console.aws.amazon.com/rds/home#databases:)
-    is in the stopped state. So much for a "quick" start! If you don't want to
-    wait, see
+    is stopped. After clicking the RDS database instance name or the Aurora
+    database cluster name, open the "Logs & events" tab and scroll to "Recent
+    events". At the right, click to change "Last 1 day" to "Last 2 weeks". The
+    "System notes" column should include the following entries, listed here
+    from newest to oldest:
+
+    |RDS Database Instance|Aurora Database Cluster|
+    |:---|:---|
+    |DB instance stopped|DB cluster stopped|
+    |DB instance started|DB cluster started|
+    |DB instance is being started due to it exceeding the maximum allowed time being stopped.|DB cluster is being started due to it exceeding the maximum allowed time being stopped.|
+
+    (Recovery, restart, and other events may appear in between.)
+
+    So much for a "quick" start! If you don't want to wait the 8 days, see
     [Testing](#testing),
     below.
 
- 4. Optional: Double-check in the
-    [StayStopped CloudWatch log group](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups$3FlogGroupNameFilter$3DStayStoppedRdsAurora-).
-
 ## Multi-Account, Multi-Region
 
-For reliability, Stay-Stopped works completely independently in each region, in
-each AWS account. To deploy in multiple regions and/or AWS accounts,
+For reliability, Stay-Stopped works independently in each region, in each AWS
+account. To deploy in multiple regions and/or AWS accounts,
 
  1. Delete any standalone `StayStoppedRdsAurora` CloudFormation _stacks_ in
     your target regions and/or AWS accounts.
@@ -287,7 +305,7 @@ and
 [RDS-EVENT-0151](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Events.Messages.html#USER_Events.Messages.cluster)
 (Aurora database cluster). Although it won't stop databases that are already
 running and remain running, **&#9888; while in test mode Stay-Stopped will
-stop any database that is newly created or newly started**. To test, manually
+stop databases that you start manually**. To test, manually
 start a stopped
 [RDS or Aurora database](https://console.aws.amazon.com/rds/home#databases:).
 
@@ -375,12 +393,11 @@ hidden controls such as Service and Resource control policies (SCPs and RCPs)
 As noted in the Design section, many alternative solutions introduce a latent
 bug (a
 [race condition](https://en.wikipedia.org/wiki/Race_condition))
-by checking whether a database is ready _before_ trying to stop it,
-insisting on catching the database while it's `available`, or not waiting
-long enough.
+by checking status _before_ trying to stop a database, always expecting to
+catch the database while it's `available`, or not waiting long enough.
 
 <details>
-  <summary>More about idempotence, race conditions, latent bugs...</summary>
+  <summary>About idempotence, race conditions, and latent bugs...</summary>
 
 Consider two alternative solutions, described as of May, 2025:
 
@@ -404,10 +421,10 @@ status, _before_ the next status check?
 [Lambda has a 15-minute maximum timeout](https://docs.aws.amazon.com/lambda/latest/dg/configuration-timeout.html).
 The function might never get a chance to request that the database be stopped.
 
-> Waiting _within_ the Lambda function might seem wasteful, but in this case,
-the cost is less than 2¢ &mdash; negligible for a function triggered once per
-database per week. Lambda's maximum timeout notwithstanding, I appreciate the
-author's instinct for minimal infrastructure.
+> Waiting _within_ the Lambda function might seem wasteful, but 15 minutes
+costs less than 2¢ &mdash; negligible for a function triggered once per
+database per week. Even though Lambda's maximum timeout is too short for this
+application, I appreciate the author's instinct for minimal infrastructure.
 
 ### Step Function Alternative
 
@@ -418,13 +435,15 @@ Before attempting to stop the database, the state machine waits as long as
 necessary for the database to become `available`; long `maintenance` etc.
 would be accommodated. After the database finishes `starting` and becomes
 `available`, what if a person or system (perhaps an infrastructure-as-code
-system) happens to delete it before the next status check? That's unlikely,
-but what if someone notices that the database is now `available`, gets
-impatient, and stops it manually? Barring an error, `available` is the _only_
-way out of the status-checking loop
+system) happens to delete it before the next status check, putting it in
+`deleting` status? That's unlikely, but what if someone notices that the
+database is now `available` and stops it manually, putting it in `stopping`
+status?
+
+Barring an error, `available` is the _only_ way out of the status check loop
 ([stop-rds-instance-state-machine.json L30-L40](https://github.com/aws-samples/amazon-rds-auto-restart-protection/blob/cfdd3a1/sources/stepfunctions-code/stop-rds-instance-state-machine.json#L30-L40)).
 No
-[overall state machine timeout](https://docs.aws.amazon.com/step-functions/latest/dg/statemachine-structure.html#statemachinetimeoutseconds)
+[state machine timeout](https://docs.aws.amazon.com/step-functions/latest/dg/statemachine-structure.html#statemachinetimeoutseconds)
 is defined
 ([L1-L4](https://github.com/aws-samples/amazon-rds-auto-restart-protection/blob/cfdd3a1/sources/stepfunctions-code/stop-rds-instance-state-machine.json#L1-L4)).
 The Step Function would keep checking every 5 minutes for a status that won't
@@ -435,37 +454,37 @@ starts the database manually _with the intention of using it_.
 is made, the state machine sees it through until the database's status changes
 from `stopping` to `stopped`.
 
-![Retrieve Relational Database Service Instance State, is Instance Available?, and wait Five Minutes are joined in a loop. The only exit paths are from is Instance Available? to stop RDS Instance, if RDS Instance State is 'available'; and from retrieve RDS Instance State and stop RDS Instance to fall-back, if an error is caught.](media/aws-architecture-blog-stop-rds-instance-state-machine-annotated.png?raw=true "Annotated state machine from the AWS Architecture Blog solution")
+!['Retrieve Relational Database Service Instance State', 'is Instance Available?', and 'wait Five Minutes' are joined in a loop. The only exit paths are from 'is Instance Available?' to 'stop RDS Instance', if 'RDS Instance State' is 'available'; or from 'retrieve RDS Instance State' and 'stop RDS Instance' to 'fall-back', if an error is caught.](media/aws-architecture-blog-stop-rds-instance-state-machine-annotated.png?raw=true "Annotated state machine from the AWS Architecture Blog solution")
 
 ### Stay-Stopped: Queue Before Lambda
 
 Stay-Stopped requires only one Lambda function, but inserts an SQS queue
-between EventBridge and Lambda. The Lambda function does not wait on the
+between EventBridge and Lambda. The Lambda function never waits for the
 database. SQS counts up toward a
 [message [in]visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html),
 making it possible to periodically retry the Lambda function, with the
 original EventBridge event message, until the return value indicates success.
 If
 [maxReceiveCount](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html#policies-for-dead-letter-queues)
-is reached, SQS stops trying and moves the message to a dead letter queue.
+is reached instead, SQS gives up and moves the message to a dead letter queue.
 Between the [in]visibility timeout and the receive count, SQS maintains all
 the state that's needed.
 
-Given that the Lambda function receives the _original_ event mesasage again
+Given that the Lambda function receives the _original_ event message again
 and again, how does Stay-Stopped track the database's progress from `starting`
-toward the status from which it can be stopped (`available`) and then toward a
-final status (usually `stopped`)? It doesn't. One Lambda function does the
+to `available` (the only status from which it can be stopped) and then to
+`stopped` (or another final status)? It doesn't. One Lambda function does the
 same thing each time it's invoked, avoiding the need for a Step Function state
 machine.
 
 Each time the Lambda function is invoked, it tries to stop the database by
-calling `stop_db_cluster` (in response to an Aurora event) or
-`stop_db_instance` (RDS). Unlike a request to stop an EC2 compute instance,
-which succeeds even if the EC2 instance is stopping or already stopped, a
-request to stop an RDS database instance or an Aurora database cluster fails
-if the database is stopping or already stopped. More importantly, it also
-fails if the database is in `maintenance` or another similar status, and not
-ready to be stopped.
+calling `stop_db_cluster` (for an Aurora event) or `stop_db_instance` (for
+RDS). Unlike a request to stop an EC2 compute instance, which succeeds even if
+the EC2 instance is stopping or already stopped, a request to stop an RDS
+database instance or an Aurora database cluster fails if the database is
+`stopping` or already `stopped`. More importantly, it also fails if the
+database is in `maintenance` or another similar status, and not ready to be
+stopped.
 
  1. Aurora mentions whatever offending database status in the error message:
 
@@ -500,18 +519,18 @@ The function supports batches of event messages, each representing a different
 database to stop. It's improbable that two stopped databases would be started
 within a short window of time. Instead, partial batch responses provide a way
 to provoke retries, short of raising an exception or calling `sys.exit(1)`,
-either of which would also provoke the needless
-[shutdown and re-initialization of the Lambda runtime environment](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-invoke-with-errors).
+either of which would needlessly
+[provoke the shutdown and re-initialization of the Lambda runtime environment](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-invoke-with-errors).
 
-> Retries continue until the database reaches a final status (usually
-`stopped`). If someone starts the database manually after it enters `stopped`
-status but before Stay-Stopped detects this, Stay-Stopped will stop the
-database a second time. A race condition, yes, but one that is documented and
-doesn't interfere with the main goal: stopping! Wait until a database has been
-in `stopped` status for 9 minutes (the default [in]visibility timeout) before
-starting it. To eliminate the problem, change `FollowUntilStopped` to `false`
-in CloudFormation. Retries will stop right after the successful call to
-`stop_db_cluster` or `stop_db_instance`.
+> Retries continue until the database reaches a final status. If someone
+starts the database manually after it enters `stopped` status but before the
+next and final retry, Stay-Stopped will stop the database another time &mdash;
+a race condition, yes, but one that's documented and doesn't interfere with
+stopping stuff the first time! Before manually starting a database, wait until
+it has been `stopped` for at least 9 minutes (the tool's default
+[in]visibility timeout). To eliminate the problem, change `FollowUntilStopped`
+to `false` in CloudFormation. Retries will end as soon as AWS successfully
+receives the `stop_db_cluster` or `stop_db_instance` request.
 
 ### Further Reading
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Edit the database names in these test messages:
 ```json
 {
   "detail": {
-    "SourceIdentifier": "NAME_OF_YOUR_RDS_DATABASE_INSTANCE",
+    "SourceIdentifier": "Name-Of-Your-RDS-Database-Instance",
     "SourceType": "DB_INSTANCE",
     "EventID": "RDS-EVENT-0154"
   },
@@ -344,7 +344,7 @@ Edit the database names in these test messages:
 ```json
 {
   "detail": {
-    "SourceIdentifier": "NAME_OF_YOUR_AURORA_DATABASE_CLUSTER",
+    "SourceIdentifier": "Name-Of-Your-Aurora-Database-Cluster",
     "SourceType": "CLUSTER",
     "EventID": "RDS-EVENT-0153"
   },
@@ -365,11 +365,11 @@ manually. Edit the database names in this Lambda test event:
 {
   "Records": [
     {
-      "body": "{ \"detail\": { \"SourceIdentifier\": \"NAME_OF_YOUR_RDS_DATABASE_INSTANCE\", \"SourceType\": \"DB_INSTANCE\", \"EventID\": \"RDS-EVENT-0154\" }, \"detail-type\": \"RDS DB Instance Event\", \"source\": \"aws.rds\", \"version\": \"0\"}",
+      "body": "{ \"detail\": { \"SourceIdentifier\": \"Name-Of-Your-RDS-Database-Instance\", \"SourceType\": \"DB_INSTANCE\", \"EventID\": \"RDS-EVENT-0154\" }, \"detail-type\": \"RDS DB Instance Event\", \"source\": \"aws.rds\", \"version\": \"0\"}",
       "messageId": "test-message-1-rds"
     },
     {
-      "body": "{ \"detail\": { \"SourceIdentifier\": \"NAME_OF_YOUR_AURORA_DATABASE_CLUSTER\", \"SourceType\": \"CLUSTER\", \"EventID\": \"RDS-EVENT-0153\" }, \"detail-type\": \"RDS DB Cluster Event\", \"source\": \"aws.rds\", \"version\": \"0\"}",
+      "body": "{ \"detail\": { \"SourceIdentifier\": \"Name-Of-Your-Aurora-Database-Cluster\", \"SourceType\": \"CLUSTER\", \"EventID\": \"RDS-EVENT-0153\" }, \"detail-type\": \"RDS DB Cluster Event\", \"source\": \"aws.rds\", \"version\": \"0\"}",
       "messageId": "test-message-2-aurora"
     }
   ]
@@ -489,7 +489,7 @@ stopped.
  1. Aurora mentions whatever offending database status in the error message:
 
     > An error occurred (InvalidDBClusterStateFault) when calling the
-    StopDBCluster operation: DbCluster NAME_OF_YOUR_AURORA_DATABASE_CLUSTER
+    StopDBCluster operation: DbCluster Name-Of-Your-Aurora-Database-Cluster
     **is in stopping state** but expected it to be one of available.
 
     There is no point in checking the status of an Aurora database, separately
@@ -499,7 +499,7 @@ stopped.
  2. RDS, on the other hand, omits the offending database status:
 
     > An error occurred (InvalidDBInstanceState) when calling the
-    StopDBInstance operation: Instance NAME_OF_YOUR_RDS_DATABASE_INSTANCE
+    StopDBInstance operation: Instance Name-Of-Your-RDS-Database-Instance
     **is not in available state**.
 
     After receiving this error, the Stay-Stopped Lambda function calls

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ starts your database on the 7th day, this tool automatically stops it again.
 
 Stay-Stopped is for databases you use sporadically:
 
-- development
 - testing
+- development
 - occasional reference
 - retired, but kept just in case
 
 If it would cost too much to keep a database running but take too long to
-re-create it, this tool might save you money, time, or both.
-
-AWS does not charge for database instance hours while an
+re-create it, this tool might save you money, time, or both. AWS does not
+charge for database instance hours while an
 [RDS database instance is stopped](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html#USER_StopInstance.Benefits)
 or an
 [Aurora database cluster is stopped](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-cluster-stop-start.html#aurora-cluster-start-stop-overview).
@@ -106,15 +105,15 @@ Click to view the architecture diagram and flowchart:
     "System notes" column should include the following entries, listed here
     from newest to oldest:
 
-    |RDS Database Instance|Aurora Database Cluster|
+    |RDS|Aurora|
     |:---|:---|
     |DB instance stopped|DB cluster stopped|
     |DB instance started|DB cluster started|
     |DB instance is being started due to it exceeding the maximum allowed time being stopped.|DB cluster is being started due to it exceeding the maximum allowed time being stopped.|
 
-    (Recovery, restart, and other events may appear in between.)
+    > Recovery, restart, and other events may appear in between.
 
-    So much for a "quick" start! If you don't want to wait the 8 days, see
+    > So much for a "quick" start! If you don't want to wait the 8 days, see
     [Testing](#testing),
     below.
 
@@ -399,6 +398,7 @@ catch the database while it's `available`, or not waiting long enough.
 <details>
   <summary>About idempotence, race conditions, and latent bugs...</summary>
 
+<br/>
 Consider two alternative solutions, described as of May, 2025:
 
 ### Pure Lambda Alternative

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Check the:
       message to the main SQS queue or denies SQS permission to invoke the AWS
       Lambda function.
 
- 3. [CloudTrail Event history](https://console.aws.amazon.com/cloudtrailv2/home?ReadOnly=false/events?ReadOnly=false)
+ 3. [CloudTrail Event history](https://console.aws.amazon.com/cloudtrailv2/home?ReadOnly=false/events#/events?ReadOnly=false)
     - CloudTrail events with an "Error code" may indicate permissions
       problems,
       typically due to the local security configuration.

--- a/README.md
+++ b/README.md
@@ -505,14 +505,13 @@ either of which would also provoke the needless
 
 > Retries continue until the database reaches a final status (usually
 `stopped`). If someone starts the database manually after it enters `stopped`
-status but before Stay-Stopped detects that status, Stay-Stopped will stop the
+status but before Stay-Stopped detects this, Stay-Stopped will stop the
 database a second time. A race condition, yes, but one that doesn't interfere
-with the main goal of stopping the database (the first time)! Wait until a
-database has been in `stopped` status for 9 minutes (the default
-[in]visibility timeout) before starting it. If this is onerous, change
-`FollowUntilStopped` to `false` in CloudFormation. Retries will stop after the
-successful call to `stop_db_cluster` or `stop_db_instance`, eliminating the
-race condition.
+with the main goal of _stopping_! Wait until a database has been in `stopped`
+status for 9 minutes (the default [in]visibility timeout) before starting it.
+If this is onerous, change `FollowUntilStopped` to `false` in CloudFormation.
+retries will stop after the successful call to `stop_db_cluster` or
+`stop_db_instance`, eliminating the race condition.
 
 ### Further Reading
 

--- a/stay_stopped_aws_rds_aurora.py
+++ b/stay_stopped_aws_rds_aurora.py
@@ -116,7 +116,7 @@ def assess_db_status(db_status):
 
       case "stopped" | "deleting" | "deleted":
         log_level = INFO
-        # Terinal status, success!
+        # Terminal status, success!
 
       case (
           "starting"  # Stop not yet successfully requested

--- a/stay_stopped_aws_rds_aurora.py
+++ b/stay_stopped_aws_rds_aurora.py
@@ -5,6 +5,7 @@ github.com/sqlxpert/stay-stopped-aws-rds-aurora  GPLv3  Copyright Paul Marcelin
 """
 
 from logging import getLogger, INFO, WARNING, ERROR
+from os import environ as os_environ
 from json import dumps as json_dumps, loads as json_loads
 from re import match as re_match
 from botocore.exceptions import ClientError as botocore_ClientError
@@ -14,6 +15,8 @@ from boto3 import client as boto3_client
 logger = getLogger()
 # Skip "credentials in environment" INFO message, unavoidable in AWS Lambda:
 getLogger("botocore").setLevel(WARNING)
+
+FOLLOW_UNTIL_STOPPED = ("FOLLOW_UNTIL_STOPPED" in os_environ)  # pylint: disable=superfluous-parens
 
 
 def log(entry_type, entry_value, log_level):
@@ -336,7 +339,7 @@ def lambda_handler(lambda_event, context):  # pylint: disable=unused-argument
     stop_db_kwargs = {}
     result = None
     log_level = INFO
-    retry = True
+    retry = FOLLOW_UNTIL_STOPPED
 
     try:
       sqs_message_id = sqs_message["messageId"]

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -34,10 +34,11 @@ Parameters:
       QueueMaxReceiveCount * QueueVisibilityTimeoutSecs (defaults of 160
       times and 540 seconds or 9 minutes give 24 hours) after AWS started the
       database. If someone starts the database manually after it enters
-      "stopped" status but before that status is detected, the database will
-      be stopped and it will be necessary to wait QueueVisibilityTimeoutSecs
-      before starting it definitively. Changing this to "false" eliminates
-      the conflict window, at the expense of the completion monitoring.
+      "stopped" status but before the status is detected, the database will be
+      stopped a second time and it will be necessary to wait
+      QueueVisibilityTimeoutSecs before starting it definitively. Changing
+      this to "false" eliminates the conflict window, at the expense of the
+      completion monitoring.
     Default: "true"
     AllowedValues:
       - "false"

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -28,17 +28,17 @@ Parameters:
   FollowUntilStopped:
     Type: String
     Description: >-
-      Whether to monitor after successfully requesting that a database be
-      stopped. The default, "true", provides an ERROR-level log entry or an
-      error (dead letter) queue message if the stop request is not complete
+      Whether to monitor after requesting that a database be stopped. The
+      default, "true", provides an ERROR-level log entry or an error (dead
+      letter) queue message if the stop request is not complete
       QueueMaxReceiveCount * QueueVisibilityTimeoutSecs (defaults of 160
       times and 540 seconds or 9 minutes give 24 hours) after AWS started the
       database. If someone starts the database manually after it enters
-      "stopped" status but before the status is detected, the database will be
+      "stopped" status but before this is detected, the database will be
       stopped a second time and it will be necessary to wait
       QueueVisibilityTimeoutSecs before starting it definitively. Changing
-      this to "false" eliminates the conflict window, at the expense of the
-      completion monitoring.
+      the value to "false" eliminates the conflict window, at the expense of
+      the completion monitoring.
     Default: "true"
     AllowedValues:
       - "false"

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -904,7 +904,7 @@ Resources:
 
                 case "stopped" | "deleting" | "deleted":
                   log_level = INFO
-                  # Terinal status, success!
+                  # Terminal status, success!
 
                 case (
                     "starting"  # Stop not yet successfully requested

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -34,11 +34,11 @@ Parameters:
       QueueMaxReceiveCount * QueueVisibilityTimeoutSecs (defaults of 160
       times and 540 seconds or 9 minutes give 24 hours) after AWS started the
       database. If someone starts the database manually after it enters
-      "stopped" status but before this is detected, the database will be
-      stopped a second time and it will be necessary to wait
-      QueueVisibilityTimeoutSecs before starting it definitively. Changing
-      the value to "false" eliminates the conflict window, at the expense of
-      the completion monitoring.
+      "stopped" status but before the next and final retry, the database will
+      be stopped another time. This window lasts QueueVisibilityTimeoutSecs
+      (540 seconds or 9 minutes, by default) and occurs every 7th day, but at
+      an unpredictable time of day. Changing the value to "false" eliminates
+      the conflict window, at the expense of the completion monitoring.
     Default: "true"
     AllowedValues:
       - "false"

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -25,6 +25,24 @@ Parameters:
       - "false"
       - "true"
 
+  FollowUntilStopped:
+    Type: String
+    Description: >-
+      Whether to monitor after successfully requesting that a database be
+      stopped. The default, "true", provides an ERROR-level log entry or an
+      error (dead letter) queue message if the stop request is not complete
+      QueueMaxReceiveCount * QueueVisibilityTimeoutSecs (defaults of 160
+      times and 540 seconds or 9 minutes give 24 hours) after AWS started the
+      database. If someone starts the database manually after it enters
+      "stopped" status but before that status is detected, the database will
+      be stopped and it will be necessary to wait QueueVisibilityTimeoutSecs
+      before starting it definitively. Changing this to "false" eliminates
+      the conflict window, at the expense of the completion monitoring.
+    Default: "true"
+    AllowedValues:
+      - "false"
+      - "true"
+
   PlaceholderAdvancedParameters:
     Type: String
     Default: ""
@@ -222,6 +240,7 @@ Metadata:
           default: Essential
         Parameters:
           - Enable
+          - FollowUntilStopped
       - Label:
           default: Advanced...
         Parameters:
@@ -260,6 +279,8 @@ Metadata:
         default: Suggested stack name
       Enable:
         default: Enable?
+      FollowUntilStopped:
+        default: Follow the database after a stop request?
       PlaceholderAdvancedParameters:
         default: Do not change the parameters below, unless necessary!
       Test:
@@ -296,6 +317,8 @@ Metadata:
 Conditions:
 
   EnableTrue: !Equals [ !Ref Enable, "true" ]
+
+  FollowUntilStoppedTrue: !Equals [ !Ref FollowUntilStopped, "true" ]
 
   TestTrue: !Equals [ !Ref Test, "true" ]
 
@@ -755,6 +778,10 @@ Resources:
       Architectures:
         - arm64
       Runtime: python3.13
+      Environment:
+        Variables:
+          "FOLLOW_UNTIL_STOPPED":
+            !If [ FollowUntilStoppedTrue, "", !Ref AWS::NoValue ]
       Handler: index.lambda_handler
       Code:
         ZipFile: |
@@ -765,6 +792,7 @@ Resources:
           """
 
           from logging import getLogger, INFO, WARNING, ERROR
+          from os import environ as os_environ
           from json import dumps as json_dumps, loads as json_loads
           from re import match as re_match
           from botocore.exceptions import ClientError as botocore_ClientError
@@ -774,6 +802,8 @@ Resources:
           logger = getLogger()
           # Skip "credentials in environment" INFO message, unavoidable in AWS Lambda:
           getLogger("botocore").setLevel(WARNING)
+
+          FOLLOW_UNTIL_STOPPED = ("FOLLOW_UNTIL_STOPPED" in os_environ)  # pylint: disable=superfluous-parens
 
 
           def log(entry_type, entry_value, log_level):
@@ -1096,7 +1126,7 @@ Resources:
               stop_db_kwargs = {}
               result = None
               log_level = INFO
-              retry = True
+              retry = FOLLOW_UNTIL_STOPPED
 
               try:
                 sqs_message_id = sqs_message["messageId"]


### PR DESCRIPTION
- Adds the option **not** to follow the database through to `stopped` or another final status after `stop_db_instance` or `stop_db_cluster` returns with success.
- Adds a table of expected events to the Get Started section of the ReadMe file.
- Increases clarity throughout the ReadMe.