### PR TITLE
Also respect FollowUntilStopped for external stop request

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ default [in]visibility timeout, 9 minutes). Or, change `FollowUntilStopped` to
 ### Amazon Q Artificial Intelligence Solutions
 
 After finishing Stay-Stopped, I decided to check whether
-[Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-chat.html)
+[Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/software-dev.html)
 might have helped with its development. This section is so dispiriting that
 I'm folding it. Read on, if you dare!
 
@@ -896,8 +896,15 @@ code that Amazon Q Developer generates. If you don't know general programming
 principles, you risk accepting generated code that is long, repetitive, and
 hard to maintain.
 
-I edited my prompts for brevity and reduced the indentation of the generated
-code excerpts for readability. Originals are available on request.
+> I have edited my prompts for brevity and reduced the indentation of the
+generated code excerpts for readability. Originals are available on request.
+Because the goal was to see whether artificial intelligence could develop a
+solution from scratch, replacing an experienced human developer or at least
+guiding a novice, I did not provide the Stay-Stopped code as context. "You can
+start an entirely new project...", according to the _Amazon Q User Guide_. I
+did not find attribution information while using Amazon Q Developer. If you
+claim credit for any part of the generated code and would like me to
+acknowledge your work, please get in touch.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ Check the:
       usually after trying for 24 hours.
     - The message will usually be the original EventBridge event from when AWS
       started the database after it had been stopped for 7 days.
+    - Rarely, a message in this queue indicates that the local security
+      configuration is denying necessary access to SQS or Lambda.
 
  3. [CloudTrail Event history](https://console.aws.amazon.com/cloudtrailv2/home?ReadOnly=false/events#/events?ReadOnly=false)
     - CloudTrail events with an "Error code" may indicate permissions

--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ Check the:
       usually after trying for 24 hours.
     - The message will usually be the original EventBridge event from when AWS
       started the database after it had been stopped for 7 days.
-    - Other message types are possible in rare cases.
 
  3. [CloudTrail Event history](https://console.aws.amazon.com/cloudtrailv2/home?ReadOnly=false/events#/events?ReadOnly=false)
     - CloudTrail events with an "Error code" may indicate permissions

--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ variable, a function, and a `describe_db_instances` call, comprising 14+ extra
 lines of executable Python code. My earlier complaint that
 `describe_db_instances` does indeed return tags seems to have biased the bot
 against `list_tags_for_resource`, which would be appropriate this time &mdash;
-_if_ it were necessary to fetch tags and if tags made sense for this
+if it were necessary to fetch tags and if tags made sense for this
 application.
 
 ```json

--- a/README.md
+++ b/README.md
@@ -389,8 +389,8 @@ catch the database while it's `available`, or not waiting long enough.
   <summary>About idempotence, race conditions, and latent bugs...</summary>
 
 <br/>
-Let's compare two alternative solutions, described as of May, 2025, then
-Stay-Stopped, and finally, a series of AI-generated solution from June,
+Let's compare two thoughtful alternative solutions, described as of May, 2025,
+then Stay-Stopped, and finally, a series of AI-generated solution from June,
 2025...
 
 ### Pure Lambda Alternative

--- a/README.md
+++ b/README.md
@@ -250,15 +250,11 @@ Check the:
 
  2. `StayStoppedRdsAurora-ErrorQueue` (dead letter)
     [SQS queue](https://console.aws.amazon.com/sqs/v3/home#/queues)
-    - The presence of a message in this queue means that Stay-Stopped did not
-      stop a database, usually after trying for 24 hours.
+    - A message in this queue means that Stay-Stopped did not stop a database,
+      usually after trying for 24 hours.
     - The message will usually be the original EventBridge event from when AWS
       started the database after it had been stopped for 7 days.
-    - Different message types are possible in rare cases, such as if critical
-      Stay-Stopped components have been modified or deleted, or the local
-      security configuration denies EventBridge permission to send an event
-      message to the main SQS queue or denies SQS permission to invoke the AWS
-      Lambda function.
+    - Other message types are possible in rare cases.
 
  3. [CloudTrail Event history](https://console.aws.amazon.com/cloudtrailv2/home?ReadOnly=false/events#/events?ReadOnly=false)
     - CloudTrail events with an "Error code" may indicate permissions

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Stay-Stopped, and finally, a series of AI-generated solution from June,
 
 [Stop Amazon RDS/Aurora Whenever They Start](https://aws.plainenglish.io/stop-amazon-rds-aurora-whenever-they-start-with-lambda-and-eventbridge-c8c1a88f67d6)
 \[[code](https://gist.github.com/shimo164/cc9bb3c425e13f0f2fa14f29c633aa84/0e714a830352e6e6d29904e0629b82df5473393f)\]
-by shimo, from the _AWS In Plain English_ blog on Medium, comprises a single
+by shimo, from the _AWS in Plain English_ blog on Medium, comprises a single
 Lambda function, which checks that the database is `available` before stopping
 it
 ([L48-L51](https://gist.github.com/shimo164/cc9bb3c425e13f0f2fa14f29c633aa84/0e714a830352e6e6d29904e0629b82df5473393f#file-lambda_stop_rds-py-L48-L51)).
@@ -539,8 +539,8 @@ Jump to:
 Amazon Q Developer's initial response to my prompt to write a Lambda function
 that keeps RDS databases stopped longer than 7 days didn't handle events at
 all. It drew a list of databases from `describe_db_instances` and called
-`stop_db_instance` on any `available` ones that had been created more than 7
-days ago &mdash; disaster, even in non-production environments!
+`stop_db_instance` on `available` ones that had been created more than 7 days
+ago &mdash; disaster!
 
 #### An Unnecessary Call for Every Database
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ Click to view the architecture diagram and flowchart:
     |:---|:---|
     |DB instance stopped|DB cluster stopped|
     |DB instance started|DB cluster started|
+    |_Other events possible during startup_|_Other events possible during startup_|
     |DB instance is being started due to it exceeding the maximum allowed time being stopped.|DB cluster is being started due to it exceeding the maximum allowed time being stopped.|
-
-    > Recovery, restart, and other events may appear in between.
 
     > So much for a "quick" start! If you don't want to wait the 8 days, see
     [Testing](#testing),

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Click to view the architecture diagram and flowchart:
     |:---|:---|
     |DB instance stopped|DB cluster stopped|
     |DB instance started|DB cluster started|
-    |_Other events possible during startup_|_Other events possible during startup_|
+    |_Various other events possible during startup_|_Various other events possible during startup_|
     |DB instance is being started due to it exceeding the maximum allowed time being stopped.|DB cluster is being started due to it exceeding the maximum allowed time being stopped.|
 
     > So much for a "quick" start! If you don't want to wait the 8 days, see

--- a/README.md
+++ b/README.md
@@ -105,13 +105,12 @@ Click to view the architecture diagram and flowchart:
     database cluster name, open the "Logs & events" tab and scroll to "Recent
     events". At the right, click to change "Last 1 day" to "Last 2 weeks". The
     "System notes" column should include the following entries, listed here
-    from newest to oldest:
+    from newest to oldest. There might be other entries in between.
 
     |RDS|Aurora|
     |:---|:---|
     |DB instance stopped|DB cluster stopped|
     |DB instance started|DB cluster started|
-    |_Various other events possible during startup_|_Various other events possible during startup_|
     |DB instance is being started due to it exceeding the maximum allowed time being stopped.|DB cluster is being started due to it exceeding the maximum allowed time being stopped.|
 
     > So much for a "quick" start! If you don't want to wait the 8 days, see

--- a/README.md
+++ b/README.md
@@ -420,8 +420,6 @@ and checks again
 What if the database takes a long time to start? Startup "can take minutes to
 hours", according to the
 [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StartInstance.html).
-What if the database goes from `available` to `maintenance` or another similar
-status, _before_ the next status check?
 [Lambda has a 15-minute maximum timeout](https://docs.aws.amazon.com/lambda/latest/dg/configuration-timeout.html).
 The function might never get a chance to request that the database be stopped.
 
@@ -439,8 +437,8 @@ Before attempting to stop the database, the state machine waits as long as
 necessary for the database to become `available`; long `maintenance` etc.
 would be accommodated. After the database finishes `starting` and becomes
 `available`, what if someone notices and stops it manually, putting it in
-`stopping` status? Barring an error, `available` is the _only_ way out of the
-status check loop
+`stopping` status before the next status check? Barring an error, `available`
+is the _only_ way out of the status check loop
 ([stop-rds-instance-state-machine.json L30-L40](https://github.com/aws-samples/amazon-rds-auto-restart-protection/blob/cfdd3a1/sources/stepfunctions-code/stop-rds-instance-state-machine.json#L30-L40)).
 No
 [state machine timeout](https://docs.aws.amazon.com/step-functions/latest/dg/statemachine-structure.html#statemachinetimeoutseconds)

--- a/stay_stopped_aws_rds_aurora.py
+++ b/stay_stopped_aws_rds_aurora.py
@@ -116,11 +116,15 @@ def assess_db_status(db_status):
 
       case "stopped" | "deleting" | "deleted":
         log_level = INFO
-        # Terminal status, success!
+        # Final status, success!
+
+      case "stopping":
+        log_level = INFO
+        retry = FOLLOW_UNTIL_STOPPED
+        # Stop not yet confirmed
 
       case (
           "starting"  # Stop not yet successfully requested
-        | "stopping"  # Stop not yet confirmed
         | "backing-up"
         | "maintenance"
         | "modifying"

--- a/stay_stopped_aws_rds_aurora.py
+++ b/stay_stopped_aws_rds_aurora.py
@@ -154,7 +154,8 @@ def assess_db_status(db_status):
         # Status will probably change
 
       case (
-          "inaccessible-encryption-credentials-recoverable"
+          "available"  # Not expected after stop_db_instance/stop_db_cluster
+        | "inaccessible-encryption-credentials-recoverable"
         # RDS database instance only:
         | "incompatible-network"
         | "incompatible-option-group"

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -904,11 +904,15 @@ Resources:
 
                 case "stopped" | "deleting" | "deleted":
                   log_level = INFO
-                  # Terminal status, success!
+                  # Final status, success!
+
+                case "stopping":
+                  log_level = INFO
+                  retry = FOLLOW_UNTIL_STOPPED
+                  # Stop not yet confirmed
 
                 case (
                     "starting"  # Stop not yet successfully requested
-                  | "stopping"  # Stop not yet confirmed
                   | "backing-up"
                   | "maintenance"
                   | "modifying"

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -942,7 +942,8 @@ Resources:
                   # Status will probably change
 
                 case (
-                    "inaccessible-encryption-credentials-recoverable"
+                    "available"  # Not expected after stop_db_instance/stop_db_cluster
+                  | "inaccessible-encryption-credentials-recoverable"
                   # RDS database instance only:
                   | "incompatible-network"
                   | "incompatible-option-group"


### PR DESCRIPTION
- FollowUntilStopped / FOLLOW_UNTIL_STOPPED should also determine whether retries continue if the internal stop_db_ request never succeeds. If an external stop_db_ request succeeds, the first clue will be seeing the stopping status.
- Accept available status as (hopefully brief) retriable ERROR
- Sharpens the focus of the ReadMe.