### PR TITLE
ABAC exclusion and inclusion tags in Lambda fn role

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ application.
     }
   }
 }
+```
 
 When I added ABAC to the Stay-Stopped Lambda function role, I took the
 liberty of using the same declarative CloudFormation code to condition the
@@ -928,7 +929,6 @@ event rule on database tags. I was able to add support for a parameterized
 exclusion tag, a parameterized inclusion tag, a mix of both (databases
 explicitly included, and some explicitly excluded), or no tags. There is no
 need to add or change Lambda function Python code to support tags.
-```
 
 #### Leaving a Bug for Later
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ entirely at your own risk. You are encouraged to review the source code.
   denying authority to stop certain production databases (`AttachLocalPolicy`
   in CloudFormation).
 
+  - Tagging an RDS database instance or an Aurora database cluster with
+    `StayStopped-Exclude` (see `ExcludeTagKey` in CloudFormation) prevents the
+    Lambda function role from being misused to stop that database.
+    &#9888; Do not rely on
+    [attribute-based access control](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html)
+    unless you also prevent people and systems from adding, changing and
+    deleting ABAC tags.
+
 - Enable the test mode only in a non-critical AWS account and region, and turn
   the test mode off again as quickly as possible.
 
@@ -826,14 +834,13 @@ a `stop_db_instance` call bracketed by "Stopping RDS instance" and
 When the goal is to stop databases that had already been stopped for 7 days,
 tags cannot add any information. A previously stopped database is included,
 thanks to `RDS-EVENT-0154`. A continuously running database is excluded,
-because no event is generated for it. (The only benefit of tags would be
+because no event is generated for it. (The only benefit of tags is
 [attribute-based access control](https://aws.amazon.com/identity/attribute-based-access-control/),
 which is far beyond the level of solutions typically found on the Internet or
 initially proposed by Amazon Q Developer.
-[github.com/sqlxpert/lights-off-aws uses ABAC](https://github.com/sqlxpert/lights-off-aws/blob/8e45026/cloudformation/lights_off_aws.yaml#L679-L687).
-To implement ABAC for Stay-Stopped, you can write a customer-managed IAM
-policy and set `LambdaFnRoleAttachLocalPolicyName`. Unless you universally
-restrict the right to add, change and delete ABAC tags, the policy is moot.)
+[github.com/sqlxpert/lights-off-aws uses ABAC](https://github.com/sqlxpert/lights-off-aws/blob/8e45026/cloudformation/lights_off_aws.yaml#L679-L687)
+and I've added it to Stay-Stopped as well. It's moot unless you broadly
+restrict the right to add, change and delete ABAC tags.)
 
 According to Amazon Q Developer, "The final solution represents a robust,
 production-ready approach that properly handles the complexities of keeping
@@ -914,6 +921,13 @@ application.
     }
   }
 }
+
+When I added ABAC to the Stay-Stopped Lambda function role, I took the
+liberty of using the same declarative CloudFormation code to condition the
+event rule on database tags. I was able to add support for a parameterized
+exclusion tag, a parameterized inclusion tag, a mix of both (databases
+explicitly included, and some explicitly excluded), or no tags. There is no
+need to add or change Lambda function Python code to support tags.
 ```
 
 #### Leaving a Bug for Later

--- a/stay_stopped_aws_rds_aurora.yaml
+++ b/stay_stopped_aws_rds_aurora.yaml
@@ -50,6 +50,31 @@ Parameters:
     AllowedValues:
       - ""
 
+  ExcludeTagKey:
+    Type: String
+    Description: >-
+      An RDS database instance or Aurora database cluster with this tag will
+      not be stopped.
+      Specify only the tag key; tag values are ignored.
+      If ExcludeTagKey and IncludeTagKey are both blank, the Lambda function
+      role has permission to stop any database (though the Lambda function is
+      only triggered for databases that have already been stopped for 7 days).
+      The default is "StayStopped-Exclude".
+      For tag key rules, see
+      https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#Overview.Tagging.Structure
+    Default: "StayStopped-Exclude"
+
+  IncludeTagKey:
+    Type: String
+    Description: >-
+      An RDS database instance or Aurora database cluster without this tag will
+      not be stopped.
+      By default, this is blank and no database tag is required.
+      If a database has both the ExcludeTagKey and the IncludeTagKey, it will
+      not be stopped; exclusion wins.
+      See ExcludeTagKey for other important details.
+    Default: ""
+
   Test:
     Type: String
     Description: >-
@@ -258,6 +283,11 @@ Metadata:
         Parameters:
           - PlaceholderAdvancedParameters
       - Label:
+          default: Database tags
+        Parameters:
+          - ExcludeTagKey
+          - IncludeTagKey
+      - Label:
           default: Testing
         Parameters:
           - Test
@@ -296,6 +326,10 @@ Metadata:
         default: Follow the database after a stop request?
       PlaceholderAdvancedParameters:
         default: Do not change the parameters below, unless necessary!
+      ExcludeTagKey:
+        default: Do not stop an eligible database if it has this tag
+      IncludeTagKey:
+        default: Stop an eligible database only if it has this tag
       Test:
         default: Test mode?
       QueueDelaySecs:
@@ -334,6 +368,11 @@ Conditions:
   EnableTrue: !Equals [ !Ref Enable, "true" ]
 
   FollowUntilStoppedTrue: !Equals [ !Ref FollowUntilStopped, "true" ]
+
+  ExcludeTagKeySet: !Not [ !Equals [ !Ref ExcludeTagKey, "" ] ]
+  IncludeTagKeySet: !Not [ !Equals [ !Ref IncludeTagKey, "" ] ]
+  ExcludeTagKeySetOrIncludeTagKeySet:
+    !Or [ !Condition ExcludeTagKeySet, !Condition IncludeTagKeySet ]
 
   TestTrue: !Equals [ !Ref Test, "true" ]
 
@@ -426,10 +465,29 @@ Resources:
                   "Resource": [
                     "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*",
                     "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
-                  ]
+                  ],
+                  "Condition": {
+              ${TagConditions}
+                  }
                 }]
               }
-            - PlaceholderKeyForFutureUse: PlaceholderValueForFutureUse
+            - TagConditions: !Join
+                - |
+                  ,
+                - - !If
+                    - ExcludeTagKeySet
+                    - !Sub |-
+                        "StringNotLike": {
+                          "aws:ResourceTag/${ExcludeTagKey}": "*"
+                        }
+                    - !Ref AWS::NoValue
+                  - !If
+                    - IncludeTagKeySet
+                    - !Sub |-
+                        "StringLike": {
+                          "aws:ResourceTag/${IncludeTagKey}": "*"
+                        }
+                    - !Ref AWS::NoValue
 
         - Fn::If:
             - SqsKmsKeyCustom
@@ -641,7 +699,7 @@ Resources:
             "source": [ "aws.rds" ],
             "detail": {
               "SourceIdentifier": [ { "anything-but": [ "" ] } ],
-              "Date": [ { "anything-but": [ "" ] } ]
+              "Date": [ { "anything-but": [ "" ] } ]${DetailTagsKey}
             },
             "$or": [
               {
@@ -660,13 +718,28 @@ Resources:
               }
             ]
           }
-        - AuroraTestEvent: !If
-            - TestTrue
-            - ', "RDS-EVENT-0151"'
-            - ""
-          RdsTestEvent: !If
-            - TestTrue
-            - ', "RDS-EVENT-0088"'
+        - AuroraTestEvent: !If [ TestTrue, ', "RDS-EVENT-0151"', "" ]
+          RdsTestEvent: !If [ TestTrue, ', "RDS-EVENT-0088"', "" ]
+          DetailTagsKey: !If
+            - ExcludeTagKeySetOrIncludeTagKeySet
+            - !Sub
+              - |-
+                  ,
+                  "Tags": {
+                    ${DetailTagsValue}
+                  }
+              - DetailTagsValue: !Join
+                  - ', '
+                  - - !If
+                      - ExcludeTagKeySet
+                      - !Sub |-
+                          "${ExcludeTagKey}": [ { "exists": false } ]
+                      - !Ref AWS::NoValue
+                    - !If
+                      - IncludeTagKeySet
+                      - !Sub |-
+                          "${IncludeTagKey}": [ { "exists": true } ]
+                      - !Ref AWS::NoValue
             - ""
       # Would prefer "anything-but": [ "", null ] . JSON EventPattern resolves:
       # https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1378


### PR DESCRIPTION
- Event rule also makes use of tags, though to be clear, there is no need for tagging in this application. RDS-EVENT-0154 and RDS-EVENT-0153 are generated only for databases that have been stopped for 7 days, not for continuously-running databases.
- ABAC is not effective unless you also prevent people and systems from adding, changing and deleting critical tags.